### PR TITLE
Fix link syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A [babushka](1) like clone, written in bash.
+A [babushka][1] like clone, written in bash.
 
 ## Installing
 


### PR DESCRIPTION
Pretty much :octocat: 
